### PR TITLE
Upgrade to Spring Boot 3.5.13, Java 21, and resolve OSS vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
 
     - name: Cache Maven packages
       uses: actions/cache@v4

--- a/account/Dockerfile
+++ b/account/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:21-jre-jammy
 LABEL authors="halversondm"
 
 ARG JAR_FILE=target/account-1.0.0.jar

--- a/book/Dockerfile
+++ b/book/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:21-jre-jammy
 LABEL authors="halversondm"
 
 ARG JAR_FILE=target/book-1.0.0.jar

--- a/customer/Dockerfile
+++ b/customer/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:21-jre-jammy
 LABEL authors="halversondm"
 
 ARG JAR_FILE=target/customer-1.0.0.jar

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:21-jre-jammy
 LABEL authors="halversondm"
 
 ARG JAR_FILE=target/gateway-1.0.0.jar

--- a/liquibase/Dockerfile
+++ b/liquibase/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:21-jre-jammy
 LABEL authors="halversondm"
 
 ARG JAR_FILE=target/liquibase-1.0.0.jar

--- a/liquibase/pom.xml
+++ b/liquibase/pom.xml
@@ -13,7 +13,7 @@
 	<name>liquibase</name>
 	<description>liquibase for the customer, account and book domains</description>
 	<properties>
-		<java.version>17</java.version>
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -31,12 +31,12 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.7.4</version>
+			<version>42.7.10</version>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>2.2.224</version>
+			<version>2.4.240</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.10</version>
+        <version>3.5.13</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
+        <lombok.version>1.18.44</lombok.version>
     </properties>
 
     <groupId>com.halversondm</groupId>
@@ -25,17 +26,30 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>2023.0.2</version>
+                <version>2025.0.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-properties-migrator</artifactId>
-                <scope>runtime</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <modules>
         <module>book</module>


### PR DESCRIPTION
- Spring Boot 3.2.10 -> 3.5.13
- Spring Cloud BOM 2023.0.2 -> 2025.0.2 (Northfields)
- Java 17 -> 21 across all modules and Dockerfiles
- Lombok 1.18.44 (Java 25 JVM compat) with explicit annotationProcessorPaths
- PostgreSQL JDBC 42.7.4 -> 42.7.10 (fixes channel-binding auth CVE)
- H2 2.2.224 -> 2.4.240
- Docker base image: openjdk:17-jdk-slim -> eclipse-temurin:21-jre-jammy
- Remove spring-boot-properties-migrator (no longer needed)
- CI pipeline updated to JDK 21