### PR TITLE
Upgrade to Spring Boot 4.0.5, Spring Cloud 2025.1.1, resolve OSS vuln…

### DIFF
--- a/account/src/main/java/com/halversondm/cloud/AccountDao.java
+++ b/account/src/main/java/com/halversondm/cloud/AccountDao.java
@@ -4,7 +4,7 @@ import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
 
-public interface AccountDao extends CrudRepository<Account, Long> {
+public interface AccountDao extends CrudRepository<Account, Integer> {
 
     Account findByNumber(String number);
 

--- a/customer/src/test/java/com/halversondm/cloud/CustomerApplicationTest.java
+++ b/customer/src/test/java/com/halversondm/cloud/CustomerApplicationTest.java
@@ -2,8 +2,10 @@ package com.halversondm.cloud;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class CustomerApplicationTest {
 
     @Test

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -17,7 +17,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-gateway</artifactId>
+            <artifactId>spring-cloud-starter-gateway-server-webflux</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -3,25 +3,27 @@ spring:
     name: gateway-service
   cloud:
     gateway:
-      routes:
-      - id: account-service
-        uri: http://account:8080
-        predicates:
-        - Path=/account/**
-        filters:
-        - StripPrefix=1
-      - id: customer-service
-        uri: http://customer:8080
-        predicates:
-        - Path=/customer/**
-        filters:
-        - StripPrefix=1
-      - id: book-service
-        uri: http://book:8080
-        predicates:
-          - Path=/book/**
-        filters:
-          - StripPrefix=1
+      server:
+        webflux:
+          routes:
+          - id: account-service
+            uri: http://account:8080
+            predicates:
+            - Path=/account/**
+            filters:
+            - StripPrefix=1
+          - id: customer-service
+            uri: http://customer:8080
+            predicates:
+            - Path=/customer/**
+            filters:
+            - StripPrefix=1
+          - id: book-service
+            uri: http://book:8080
+            predicates:
+              - Path=/book/**
+            filters:
+              - StripPrefix=1
 
 management:
   endpoints:

--- a/liquibase/pom.xml
+++ b/liquibase/pom.xml
@@ -31,12 +31,10 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.7.10</version>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>2.4.240</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.13</version>
+        <version>4.0.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>2025.0.2</version>
+                <version>2025.1.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
…erabilities

- Bump spring-boot-starter-parent 3.5.13 → 4.0.5 (Spring Framework 7.0.6, Hibernate 7.2.7)
- Bump spring-cloud-dependencies 2025.0.2 → 2025.1.1
- Rename gateway dependency: spring-cloud-starter-gateway → spring-cloud-starter-gateway-server-webflux
- Update gateway routes config key to spring.cloud.gateway.server.webflux.*
- Remove pinned postgresql/h2 versions in liquibase module (now BOM-managed)
- Fix AccountDao generic type Long → Integer to match Account @Id field
- Add @ActiveProfiles("test") to CustomerApplicationTest